### PR TITLE
Add missing select tags for issue #88

### DIFF
--- a/A-Z-dropdown.html
+++ b/A-Z-dropdown.html
@@ -240,6 +240,7 @@
 <option value="hume">Hume</option>
 <option value="hypertalk">HyperTalk</option>
 <option value="hy">Hy</option>
+</select>
 <!-- End H -->
 
 <!-- Begin I -->
@@ -281,7 +282,7 @@
   <option value="java">Java</option>
   <option value="javafx script">JavaFX Script</option>
   <option value="javascript">JavaScript</option>
-
+</select>
 <!-- End J -->
 
 <!-- Begin K -->
@@ -452,6 +453,7 @@
 <!-- End R -->
 
 <!-- Begin S -->
+<select>
 <option value="s">S</option>
 <option value="s2">S2</option>
 <option value="s3">S3</option>
@@ -522,6 +524,7 @@
 <option value="swift apple">Swift (Apple programming language)</option>
 <option value="swift scripting">Swift (parallel scripting language)</option>
 <option value="sympl">SYMPL</option>
+</select>
 <!-- End S -->
 
 <!-- Begin T -->
@@ -536,6 +539,7 @@
 <option value="uniface">Uniface</option>
 <option value="unity">UNITY</option>
 <option value="unrealscript">UnrealScript</option>
+</select>
 <!-- End U -->
 
 <!-- Begin V -->


### PR DESCRIPTION
There were many select tags missing which caused many of the dropdown's options to be plain text, which was not intended. This fixes issue #88 